### PR TITLE
Add tool to list all available certificates in Azure Key Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Here's all you need to do:
 - Run Azure Cosmos DB queries by just asking questions in plain English
 - Retrieve secret values from Azure Key Vault
 - Check whether a certificate in Azure Key Vault is nearly expired
+- List all available certificates in Azure Key Vault
 
 ## Quick Start 🚀
 
@@ -112,6 +113,13 @@ Claude: *fetches the secret value from Azure Key Vault and provides it to you*
 ```text
 You: "Check if the certificate 'myCertificate' is nearly expired"
 Claude: *checks the expiry date of the certificate in Azure Key Vault and informs you of the days remaining until expiry*
+```
+
+#### Listing All Available Certificates in Azure Key Vault
+
+```text
+You: "List all available certificates in Azure Key Vault"
+Claude: *lists all available certificates in Azure Key Vault and provides the details to you*
 ```
 
 ## Contributing

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,16 @@ const CHECK_CERTIFICATE_EXPIRY_TOOL: Tool = {
   },
 };
 
+const LIST_CERTIFICATES_TOOL: Tool = {
+  name: "list_certificates",
+  description: "Lists all available certificates in Azure Key Vault",
+  inputSchema: {
+    type: "object",
+    properties: {},
+  },
+  required: [],
+};
+
 async function updateItem(params: any) {
   try {
     const { id, updates } = params;
@@ -235,6 +245,27 @@ async function checkCertificateExpiry(params: any) {
   }
 }
 
+async function listCertificates() {
+  try {
+    const certificates = [];
+    for await (const certificateProperties of certificateClient.listPropertiesOfCertificates()) {
+      certificates.push(certificateProperties);
+    }
+
+    return {
+      success: true,
+      message: `Certificates listed successfully`,
+      certificates,
+    };
+  } catch (error) {
+    console.error("Error listing certificates:", error);
+    return {
+      success: false,
+      message: `Failed to list certificates: ${error}`,
+    };
+  }
+}
+
 const server = new Server(
   {
     name: "cosmosdb-mcp-server",
@@ -256,6 +287,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     UPDATE_ITEM_TOOL,
     GET_SECRET_TOOL,
     CHECK_CERTIFICATE_EXPIRY_TOOL,
+    LIST_CERTIFICATES_TOOL,
   ],
 }));
 
@@ -282,6 +314,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         break;
       case "check_certificate_expiry":
         result = await checkCertificateExpiry(args);
+        break;
+      case "list_certificates":
+        result = await listCertificates();
         break;
       default:
         return {


### PR DESCRIPTION
Add a tool to list all available certificates in Azure Key Vault.

* **src/index.ts**
  - Add a new tool definition for listing all available certificates in Azure Key Vault.
  - Add a handler function to list all available certificates in Azure Key Vault.
  - Update the `ListToolsRequestSchema` handler to include the new tool in the list of tools.

* **README.md**
  - Add an example of how to use the new tool to list all available certificates in Azure Key Vault.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hoangtruonghrs/azure-cosmos-mcp-server/pull/3?shareId=dc7dba8a-7a09-4600-8edf-b71df8a25d47).